### PR TITLE
Fix background color decrementing

### DIFF
--- a/desk-gardener/desk-gardener.ino
+++ b/desk-gardener/desk-gardener.ino
@@ -46,7 +46,7 @@ void loop() {
     }
     
     if (buttons & BUTTON_LEFT) {
-      lcdcolor = (lcdcolor - 1) % 8;
+      lcdcolor = lcdcolor ? lcdcolor - 1 : 7;
       lcd.setBacklight(lcdcolor);
       lcd.clear();
     }


### PR DESCRIPTION
This is what happens on the Arduino:

```
  (0 - 1) % 8 = -1

       -1 = 255     lcdcolor is an unsigned 8 bit integer.

colorname[255] is some byte that is constantly being overwritten by some
other code

(255 - 1) % 8 = 6
```

Here is an example program to demonstrate:

```
// g++ -std=c++11 percent.cc
#include <cstdio>
#include <cstdint>

int
main()
{
    uint8_t lcdcolor;

    std::printf("Old: \n");
    lcdcolor = 0x7;
    for (int i = 0; i < 30; ++i)
    {
        std::printf("%u\n", lcdcolor);
        lcdcolor = (lcdcolor - 1) % 8;
    }

    std::printf("New: \n");
    lcdcolor = 0x7;
    for (int i = 0; i < 30; ++i)
    {
        std::printf("%u\n", lcdcolor);
        lcdcolor = lcdcolor ? lcdcolor - 1 : 7;
    }
}
```
